### PR TITLE
Feature/1 account PR 요청

### DIFF
--- a/src/main/java/com/example/account/config/JpaAuditingConfiguration.java
+++ b/src/main/java/com/example/account/config/JpaAuditingConfiguration.java
@@ -1,0 +1,9 @@
+package com.example.account.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfiguration {
+}

--- a/src/main/java/com/example/account/controller/AccountController.java
+++ b/src/main/java/com/example/account/controller/AccountController.java
@@ -2,6 +2,7 @@ package com.example.account.controller;
 
 import com.example.account.domain.Account;
 import com.example.account.dto.CreateAccount;
+import com.example.account.dto.DeleteAccount;
 import com.example.account.service.AccountService;
 import com.example.account.service.RedisTestService;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,18 @@ public class AccountController {
                 accountService.createAccount(
                         request.getUserId(),
                         request.getInitialBalance()
+                )
+        );
+    }
+
+    @DeleteMapping("/account")
+    public DeleteAccount.Response deleteAccount(
+            @RequestBody @Valid DeleteAccount.Request request
+    ) {
+        return DeleteAccount.Response.from(
+                accountService.deleteAccount(
+                        request.getUserId(),
+                        request.getAccountNumber()
                 )
         );
     }

--- a/src/main/java/com/example/account/controller/AccountController.java
+++ b/src/main/java/com/example/account/controller/AccountController.java
@@ -1,6 +1,7 @@
 package com.example.account.controller;
 
 import com.example.account.domain.Account;
+import com.example.account.dto.AccountInfo;
 import com.example.account.dto.CreateAccount;
 import com.example.account.dto.DeleteAccount;
 import com.example.account.service.AccountService;
@@ -9,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequiredArgsConstructor
@@ -38,6 +41,19 @@ public class AccountController {
                         request.getAccountNumber()
                 )
         );
+    }
+
+    @GetMapping("/account")
+    public List<AccountInfo> getAccountsByUserId(
+            @RequestParam("user_id") Long userId
+    ) {
+        return accountService.getAccountsByUserId(userId)
+                .stream().map(accountDto ->
+                        AccountInfo.builder()
+                                .accountNumber(accountDto.getAccountNumber())
+                                .balance(accountDto.getBalance())
+                                .build())
+                .collect(Collectors.toList());
     }
 
     @GetMapping("/get-lock")

--- a/src/main/java/com/example/account/controller/AccountController.java
+++ b/src/main/java/com/example/account/controller/AccountController.java
@@ -1,12 +1,13 @@
 package com.example.account.controller;
 
 import com.example.account.domain.Account;
+import com.example.account.dto.CreateAccount;
 import com.example.account.service.AccountService;
 import com.example.account.service.RedisTestService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
 
 @RestController
 @RequiredArgsConstructor
@@ -14,15 +15,21 @@ public class AccountController {
     private final AccountService accountService;
     private final RedisTestService redisTestService;
 
+    @PostMapping("/account")
+    public CreateAccount.Response createAccount(
+            @RequestBody @Valid CreateAccount.Request request
+    ) {
+        return CreateAccount.Response.from(
+                accountService.createAccount(
+                        request.getUserId(),
+                        request.getInitialBalance()
+                )
+        );
+    }
+
     @GetMapping("/get-lock")
     public String getLock() {
         return redisTestService.getLock();
-    }
-
-    @GetMapping("/create-account")
-    public String createAccount() {
-        accountService.createAccount();
-        return "success";
     }
 
     @GetMapping("/account/{id}")

--- a/src/main/java/com/example/account/domain/AccountUser.java
+++ b/src/main/java/com/example/account/domain/AccountUser.java
@@ -1,36 +1,29 @@
 package com.example.account.domain;
 
-import com.example.account.type.AccountStatus;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import javax.persistence.*;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
 import java.time.LocalDateTime;
 
 @Getter
 @Setter
-@NoArgsConstructor
 @AllArgsConstructor
+@NoArgsConstructor
 @Builder
 @Entity
 @EntityListeners(AuditingEntityListener.class)
-public class Account {
+public class AccountUser {
     @Id
     @GeneratedValue
     private Long id;
 
-    @ManyToOne
-    private AccountUser accountUser;
-    private String accountNumber;
-
-    @Enumerated(EnumType.STRING)
-    private AccountStatus accountStatus;
-    private Long balance;
-
-    private LocalDateTime registeredAt;
-    private LocalDateTime unRegisteredAt;
+    private String name;
 
     @CreatedDate
     private LocalDateTime createdAt;

--- a/src/main/java/com/example/account/dto/AccountDto.java
+++ b/src/main/java/com/example/account/dto/AccountDto.java
@@ -1,0 +1,29 @@
+package com.example.account.dto;
+
+import com.example.account.domain.Account;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AccountDto {
+    private Long userId;
+    private String accountNumber;
+    private Long balance;
+
+    private LocalDateTime registeredAt;
+    private LocalDateTime unRegisteredAt;
+
+    public static AccountDto fromEntity(Account account) {
+        return AccountDto.builder()
+                .userId(account.getAccountUser().getId())
+                .accountNumber(account.getAccountNumber())
+                .registeredAt(account.getRegisteredAt())
+                .unRegisteredAt(account.getUnRegisteredAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/account/dto/AccountDto.java
+++ b/src/main/java/com/example/account/dto/AccountDto.java
@@ -22,6 +22,7 @@ public class AccountDto {
         return AccountDto.builder()
                 .userId(account.getAccountUser().getId())
                 .accountNumber(account.getAccountNumber())
+                .balance(account.getBalance())
                 .registeredAt(account.getRegisteredAt())
                 .unRegisteredAt(account.getUnRegisteredAt())
                 .build();

--- a/src/main/java/com/example/account/dto/AccountInfo.java
+++ b/src/main/java/com/example/account/dto/AccountInfo.java
@@ -1,0 +1,13 @@
+package com.example.account.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class AccountInfo {
+    private String accountNumber;
+    private Long balance;
+}

--- a/src/main/java/com/example/account/dto/CreateAccount.java
+++ b/src/main/java/com/example/account/dto/CreateAccount.java
@@ -1,0 +1,40 @@
+package com.example.account.dto;
+
+import lombok.*;
+
+import javax.validation.constraints.Min;
+import java.time.LocalDateTime;
+
+public class CreateAccount {
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    public static class Request {
+        @NonNull
+        @Min(1)
+        private Long userId;
+
+        @NonNull
+        @Min(100)
+        private Long initialBalance;
+    };
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Response {
+        private Long userId;
+        private String accountNumber;
+        private LocalDateTime registeredAt;
+
+        public static Response from(AccountDto accountDto) {
+            return Response.builder()
+                    .userId(accountDto.getUserId())
+                    .accountNumber(accountDto.getAccountNumber())
+                    .registeredAt(accountDto.getRegisteredAt())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/example/account/dto/DeleteAccount.java
+++ b/src/main/java/com/example/account/dto/DeleteAccount.java
@@ -3,9 +3,11 @@ package com.example.account.dto;
 import lombok.*;
 
 import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
 import java.time.LocalDateTime;
 
-public class CreateAccount {
+public class DeleteAccount {
     @Getter
     @Setter
     @AllArgsConstructor
@@ -14,9 +16,9 @@ public class CreateAccount {
         @Min(1)
         private Long userId;
 
-        @NonNull
-        @Min(0)
-        private Long initialBalance;
+        @NotBlank
+        @Size(min = 10, max = 10)
+        private String accountNumber;
     };
 
     @Getter
@@ -27,13 +29,13 @@ public class CreateAccount {
     public static class Response {
         private Long userId;
         private String accountNumber;
-        private LocalDateTime registeredAt;
+        private LocalDateTime unRegisteredAt;
 
         public static Response from(AccountDto accountDto) {
             return Response.builder()
                     .userId(accountDto.getUserId())
                     .accountNumber(accountDto.getAccountNumber())
-                    .registeredAt(accountDto.getRegisteredAt())
+                    .unRegisteredAt(accountDto.getUnRegisteredAt())
                     .build();
         }
     }

--- a/src/main/java/com/example/account/exception/AccountException.java
+++ b/src/main/java/com/example/account/exception/AccountException.java
@@ -1,0 +1,19 @@
+package com.example.account.exception;
+
+import com.example.account.type.ErrorCode;
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class AccountException extends RuntimeException {
+    private ErrorCode errorCode;
+    private String errorMessage;
+
+    public AccountException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+        this.errorMessage = errorCode.getDescription();
+    }
+}

--- a/src/main/java/com/example/account/repository/AccountRepository.java
+++ b/src/main/java/com/example/account/repository/AccountRepository.java
@@ -5,6 +5,7 @@ import com.example.account.domain.AccountUser;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -14,4 +15,6 @@ public interface AccountRepository extends JpaRepository<Account, Long> {
     Integer countByAccountUser(AccountUser accountUser);
 
     Optional<Account> findByAccountNumber(String AccountNumber);
+
+    List<Account> findByAccountUser(AccountUser accountUser);
 }

--- a/src/main/java/com/example/account/repository/AccountRepository.java
+++ b/src/main/java/com/example/account/repository/AccountRepository.java
@@ -12,4 +12,6 @@ public interface AccountRepository extends JpaRepository<Account, Long> {
     Optional<Account> findFirstByOrderByIdDesc();
 
     Integer countByAccountUser(AccountUser accountUser);
+
+    Optional<Account> findByAccountNumber(String AccountNumber);
 }

--- a/src/main/java/com/example/account/repository/AccountRepository.java
+++ b/src/main/java/com/example/account/repository/AccountRepository.java
@@ -1,9 +1,15 @@
 package com.example.account.repository;
 
 import com.example.account.domain.Account;
+import com.example.account.domain.AccountUser;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface AccountRepository extends JpaRepository<Account, Long> {
+    Optional<Account> findFirstByOrderByIdDesc();
+
+    Integer countByAccountUser(AccountUser accountUser);
 }

--- a/src/main/java/com/example/account/repository/AccountUserRepository.java
+++ b/src/main/java/com/example/account/repository/AccountUserRepository.java
@@ -1,0 +1,9 @@
+package com.example.account.repository;
+
+import com.example.account.domain.AccountUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AccountUserRepository extends JpaRepository<AccountUser, Long> {
+}

--- a/src/main/java/com/example/account/service/AccountService.java
+++ b/src/main/java/com/example/account/service/AccountService.java
@@ -8,13 +8,16 @@ import com.example.account.repository.AccountRepository;
 import com.example.account.repository.AccountUserRepository;
 import com.example.account.type.AccountStatus;
 import com.example.account.type.ErrorCode;
+import io.netty.resolver.dns.DnsServerAddresses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import static com.example.account.type.AccountStatus.IN_USE;
 import static com.example.account.type.ErrorCode.*;
@@ -93,5 +96,17 @@ public class AccountService {
         if (account.getBalance() > 0) {
             throw new AccountException(BALANCE_NOT_EMPTY);
         }
+    }
+
+    @Transactional
+    public List<AccountDto> getAccountsByUserId(Long userId) {
+        AccountUser accountUser = accountUserRepository.findById(userId)
+                .orElseThrow(() -> new AccountException(USER_NOT_FOUND));
+
+        List<Account> accounts = accountRepository
+                .findByAccountUser(accountUser);
+        return accounts.stream()
+                .map(AccountDto::fromEntity)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/example/account/service/AccountService.java
+++ b/src/main/java/com/example/account/service/AccountService.java
@@ -1,25 +1,59 @@
 package com.example.account.service;
 
 import com.example.account.domain.Account;
-import com.example.account.domain.AccountStatus;
+import com.example.account.domain.AccountUser;
+import com.example.account.dto.AccountDto;
+import com.example.account.exception.AccountException;
 import com.example.account.repository.AccountRepository;
+import com.example.account.repository.AccountUserRepository;
+import com.example.account.type.AccountStatus;
+import com.example.account.type.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
 
+import java.time.LocalDateTime;
+
+import static com.example.account.type.AccountStatus.IN_USE;
+
 @Service
 @RequiredArgsConstructor
 public class AccountService {
     private final AccountRepository accountRepository;
+    private final AccountUserRepository accountUserRepository;
 
+    /**
+     * 사용자가 있는지 조회
+     * 계좌의 번호를 생성하고
+     * 계좌를 저장하고, 그 정보를 넘긴다.
+     */
     @Transactional
-    public void createAccount() {
-        Account account = Account.builder()
-                .accountNumber("40000")
-                .accountStatus(AccountStatus.IN_USE)
-                .build();
-        accountRepository.save(account);
+    public AccountDto createAccount(Long userId, Long initialBalance) {
+        AccountUser accountUser = accountUserRepository.findById(userId)
+                .orElseThrow(() -> new AccountException(ErrorCode.USER_NOT_FOUND));
+
+        validateCreateAccount(accountUser);
+
+        String newAccountNumber = accountRepository.findFirstByOrderByIdDesc()
+                .map(account -> (Integer.parseInt(account.getAccountNumber())) + 1 + "")
+                .orElse("1000000000");
+
+        return AccountDto.fromEntity(
+                accountRepository.save(Account.builder()
+                        .accountUser(accountUser)
+                        .accountStatus(IN_USE)
+                        .accountNumber(newAccountNumber)
+                        .balance(initialBalance)
+                        .registeredAt(LocalDateTime.now())
+                        .build())
+        );
+    }
+
+    private void validateCreateAccount(AccountUser accountUser) {
+        if (accountRepository.countByAccountUser(accountUser) >= 10) {
+            throw new AccountException(ErrorCode.MAX_ACCOUNT_PER_USER_10);
+        }
     }
 
     @Transactional

--- a/src/main/java/com/example/account/service/AccountService.java
+++ b/src/main/java/com/example/account/service/AccountService.java
@@ -14,8 +14,10 @@ import org.springframework.stereotype.Service;
 import javax.transaction.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 import static com.example.account.type.AccountStatus.IN_USE;
+import static com.example.account.type.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
@@ -58,9 +60,38 @@ public class AccountService {
 
     @Transactional
     public Account getAccount(Long id) {
-        if(id < 0){
+        if (id < 0) {
             throw new RuntimeException("Minus");
         }
         return accountRepository.findById(id).get();
+    }
+
+    @Transactional
+    public AccountDto deleteAccount(Long userId, String accountNumber) {
+        AccountUser accountUser = accountUserRepository.findById(userId)
+                .orElseThrow(() -> new AccountException(ErrorCode.USER_NOT_FOUND));
+        Account account = accountRepository.findByAccountNumber(accountNumber)
+                .orElseThrow(() -> new AccountException(ErrorCode.ACCOUNT_NOT_FOUND));
+
+        validateDeleteAccount(accountUser, account);
+
+        account.setAccountStatus(AccountStatus.UNREGISTERED);
+        account.setRegisteredAt(LocalDateTime.now());
+
+        accountRepository.save(account);
+
+        return AccountDto.fromEntity(account);
+    }
+
+    private void validateDeleteAccount(AccountUser accountUser, Account account) {
+        if (!Objects.equals(accountUser.getId(), account.getAccountUser().getId())) {
+            throw new AccountException(USER_ACCOUNT_UN_MATCH);
+        }
+        if (account.getAccountStatus() == AccountStatus.UNREGISTERED) {
+            throw new AccountException(ACCOUNT_ALREADY_UNREGISTERED);
+        }
+        if (account.getBalance() > 0) {
+            throw new AccountException(BALANCE_NOT_EMPTY);
+        }
     }
 }

--- a/src/main/java/com/example/account/type/AccountStatus.java
+++ b/src/main/java/com/example/account/type/AccountStatus.java
@@ -1,4 +1,4 @@
-package com.example.account.domain;
+package com.example.account.type;
 
 public enum AccountStatus {
     IN_USE,

--- a/src/main/java/com/example/account/type/ErrorCode.java
+++ b/src/main/java/com/example/account/type/ErrorCode.java
@@ -7,6 +7,10 @@ import lombok.Getter;
 @Getter
 public enum ErrorCode {
     USER_NOT_FOUND("사용자를 찾을 수 없습니다."),
+    ACCOUNT_NOT_FOUND("계좌가 없습니다."),
+    USER_ACCOUNT_UN_MATCH("사용자와 계좌의 소유주가 다릅니다."),
+    ACCOUNT_ALREADY_UNREGISTERED("계좌가 이미 해제되었습니다."),
+    BALANCE_NOT_EMPTY("잔액이 있는 계좌는 해지할 수 없습니다."),
     MAX_ACCOUNT_PER_USER_10("사용자 최대 계좌는 10개 입니다.");
 
     private final String description;

--- a/src/main/java/com/example/account/type/ErrorCode.java
+++ b/src/main/java/com/example/account/type/ErrorCode.java
@@ -1,0 +1,13 @@
+package com.example.account.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum ErrorCode {
+    USER_NOT_FOUND("사용자를 찾을 수 없습니다."),
+    MAX_ACCOUNT_PER_USER_10("사용자 최대 계좌는 10개 입니다.");
+
+    private final String description;
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,6 @@
+insert into account_user(id, name, created_at, updated_at)
+values (1, 'Pororo', now(), now());
+insert into account_user(id, name, created_at, updated_at)
+values (2, 'Lupi', now(), now());
+insert into account_user(id, name, created_at, updated_at)
+values (3, 'Eddie', now(), now());

--- a/src/test/http/account.http
+++ b/src/test/http/account.http
@@ -1,0 +1,8 @@
+### create account
+POST http://localhost:8080/account
+Content-Type: application/json
+
+{
+  "userId": 1,
+  "initialBalance": 10000
+}

--- a/src/test/http/account.http
+++ b/src/test/http/account.http
@@ -1,10 +1,13 @@
+GET http://localhost:8080/account?user_id=1
+Accept: application/json
+
 ### create account
 POST http://localhost:8080/account
 Content-Type: application/json
 
 {
-  "userId": 2,
-  "initialBalance": 0
+  "userId": 1,
+  "initialBalance": 10004
 }
 
 ### delete account
@@ -15,3 +18,4 @@ Content-Type: application/json
   "userId": 2,
   "accountNumber": "1000000002"
 }
+

--- a/src/test/http/account.http
+++ b/src/test/http/account.http
@@ -3,6 +3,15 @@ POST http://localhost:8080/account
 Content-Type: application/json
 
 {
-  "userId": 1,
-  "initialBalance": 10000
+  "userId": 2,
+  "initialBalance": 0
+}
+
+### delete account
+DELETE http://localhost:8080/account
+Content-Type: application/json
+
+{
+  "userId": 2,
+  "accountNumber": "1000000002"
 }

--- a/src/test/java/com/example/account/controller/AccountControllerTest.java
+++ b/src/test/java/com/example/account/controller/AccountControllerTest.java
@@ -17,6 +17,8 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -83,6 +85,36 @@ class AccountControllerTest {
                 .andExpect(jsonPath("$.accountNumber").value("3456"))
                 .andExpect(jsonPath("$.accountStatus").value("IN_USE"))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    public void successGetAccountsByUserid() throws Exception {
+
+        //given
+        List<AccountDto> accountDtos =
+                Arrays.asList(AccountDto.builder()
+                                .accountNumber("1234567890")
+                                .balance(1000L).build(),
+                        AccountDto.builder()
+                                .accountNumber("1231233211")
+                                .balance(2000L).build(),
+                        AccountDto.builder()
+                                .accountNumber("2123132123")
+                                .balance(3000L).build()
+                        );
+        given(accountService.getAccountsByUserId(anyLong()))
+                .willReturn(accountDtos);
+
+        //when
+        //then
+        mockMvc.perform(get("/account?user_id=1"))
+                .andDo(print())
+                .andExpect(jsonPath("$[0].accountNumber").value("1234567890"))
+                .andExpect(jsonPath("$[0].balance").value(1000))
+                .andExpect(jsonPath("$[1].accountNumber").value("1231233211"))
+                .andExpect(jsonPath("$[1].balance").value(2000))
+                .andExpect(jsonPath("$[2].accountNumber").value("2123132123"))
+                .andExpect(jsonPath("$[2].balance").value(3000));
     }
 
     @Test

--- a/src/test/java/com/example/account/controller/AccountControllerTest.java
+++ b/src/test/java/com/example/account/controller/AccountControllerTest.java
@@ -1,20 +1,26 @@
 package com.example.account.controller;
 
 import com.example.account.domain.Account;
-import com.example.account.domain.AccountStatus;
+import com.example.account.dto.AccountDto;
+import com.example.account.dto.CreateAccount;
+import com.example.account.type.AccountStatus;
 import com.example.account.service.AccountService;
 import com.example.account.service.RedisTestService;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.junit.jupiter.api.Assertions.*;
+import java.time.LocalDateTime;
+
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -29,6 +35,35 @@ class AccountControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    public void successCreateAccount() throws Exception {
+
+        //given
+        given(accountService.createAccount(anyLong(), anyLong()))
+                .willReturn(AccountDto.builder()
+                        .userId(1L)
+                        .accountNumber("1234567890")
+                        .registeredAt(LocalDateTime.now())
+                        .unRegisteredAt(LocalDateTime.now())
+                        .build());
+
+        //when
+
+        //then
+        mockMvc.perform(post("/account")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(
+                        new CreateAccount.Request(33332L, 10023L)
+                )))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value(1))
+                .andExpect(jsonPath("$.accountNumber").value("1234567890"))
+                .andDo(print());
+    }
 
     @Test
     void successGetAccount() throws Exception {

--- a/src/test/java/com/example/account/controller/AccountControllerTest.java
+++ b/src/test/java/com/example/account/controller/AccountControllerTest.java
@@ -1,8 +1,10 @@
 package com.example.account.controller;
 
 import com.example.account.domain.Account;
+import com.example.account.domain.AccountUser;
 import com.example.account.dto.AccountDto;
 import com.example.account.dto.CreateAccount;
+import com.example.account.dto.DeleteAccount;
 import com.example.account.type.AccountStatus;
 import com.example.account.service.AccountService;
 import com.example.account.service.RedisTestService;
@@ -17,10 +19,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.time.LocalDateTime;
 
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -55,10 +57,10 @@ class AccountControllerTest {
 
         //then
         mockMvc.perform(post("/account")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(
-                        new CreateAccount.Request(33332L, 10023L)
-                )))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new CreateAccount.Request(33332L, 10023L)
+                        )))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.userId").value(1))
                 .andExpect(jsonPath("$.accountNumber").value("1234567890"))
@@ -81,5 +83,30 @@ class AccountControllerTest {
                 .andExpect(jsonPath("$.accountNumber").value("3456"))
                 .andExpect(jsonPath("$.accountStatus").value("IN_USE"))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    public void successDeleteAccount() throws Exception {
+
+        //given
+        given(accountService.deleteAccount(anyLong(), anyString()))
+                .willReturn(AccountDto.builder()
+                        .userId(1L)
+                        .accountNumber("1234567890")
+                        .registeredAt(LocalDateTime.now())
+                        .unRegisteredAt(LocalDateTime.now())
+                        .build());
+
+        //when
+        //then
+        mockMvc.perform(delete("/account")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new DeleteAccount.Request(33332L, "1111111111")
+                        )))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value(1))
+                .andExpect(jsonPath("$.accountNumber").value("1234567890"))
+                .andDo(print());
     }
 }

--- a/src/test/java/com/example/account/service/AccountServiceTest.java
+++ b/src/test/java/com/example/account/service/AccountServiceTest.java
@@ -19,8 +19,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -125,5 +124,138 @@ class AccountServiceTest {
 
         //then
         assertEquals(ErrorCode.MAX_ACCOUNT_PER_USER_10, exception.getErrorCode());
+    }
+
+    @Test
+    public void deleteAccountSuccess() throws Exception {
+        //given
+        AccountUser user = AccountUser.builder()
+                .id(12L)
+                .name("Pobi").build();
+        given(accountUserRepository.findById(anyLong()))
+                .willReturn(Optional.of(user));
+        given(accountRepository.findByAccountNumber(anyString()))
+                .willReturn(Optional.of(Account.builder()
+                        .accountUser(user)
+                        .balance(0L)
+                        .accountNumber("1000000012").build()));
+        ArgumentCaptor<Account> captor = ArgumentCaptor.forClass(Account.class);
+
+        //when
+        AccountDto accountDto = accountService.deleteAccount(1L, "1234567890");
+
+        //then
+        verify(accountRepository, times(1)).save(captor.capture());
+        assertEquals(12L, accountDto.getUserId());
+        assertEquals("1000000012", captor.getValue().getAccountNumber());
+        assertEquals(AccountStatus.UNREGISTERED, captor.getValue().getAccountStatus());
+    }
+
+    @Test
+    @DisplayName("해당 유저 없음 - 계좌 해지 실패")
+    public void deleteAccount_UserNotFound() {
+        //given
+        given(accountUserRepository.findById(anyLong()))
+                .willReturn(Optional.empty());
+
+        //when
+        AccountException exception = assertThrows(AccountException.class,
+                () -> accountService.deleteAccount(1L, "1234567890"));
+
+        //then
+        assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("해당 계좌 없음 - 계좌 해지 실패")
+    void deleteAccount_AccountNotFound() {
+        //given
+        AccountUser user = AccountUser.builder()
+                .name("Pobi").build();
+        user.setId(12L);
+        given(accountUserRepository.findById(anyLong()))
+                .willReturn(Optional.of(user));
+        given(accountRepository.findByAccountNumber(anyString()))
+                .willReturn(Optional.empty());
+
+        //when
+        AccountException exception = assertThrows(AccountException.class,
+                () -> accountService.deleteAccount(1L, "1234567890"));
+
+        //then
+        assertEquals(ErrorCode.ACCOUNT_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("계좌 소유주 다름")
+    void deleteAccountFailed_userUnMatch() {
+        //given
+        AccountUser pobi = AccountUser.builder()
+                .name("Pobi").build();
+        pobi.setId(12L);
+        AccountUser harry = AccountUser.builder()
+                .name("Harry").build();
+        harry.setId(13L);
+        given(accountUserRepository.findById(anyLong()))
+                .willReturn(Optional.of(pobi));
+        given(accountRepository.findByAccountNumber(anyString()))
+                .willReturn(Optional.of(Account.builder()
+                        .accountUser(harry)
+                        .balance(0L)
+                        .accountNumber("1000000012").build()));
+
+        //when
+        AccountException exception = assertThrows(AccountException.class,
+                () -> accountService.deleteAccount(1L, "1234567890"));
+
+        //then
+        assertEquals(ErrorCode.USER_ACCOUNT_UN_MATCH, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("해지 계좌는 잔액이 없어야 한다.")
+    void deleteAccountFailed_balanceNotEmpty() {
+        //given
+        AccountUser pobi = AccountUser.builder()
+                .name("Pobi").build();
+        pobi.setId(12L);
+        given(accountUserRepository.findById(anyLong()))
+                .willReturn(Optional.of(pobi));
+        given(accountRepository.findByAccountNumber(anyString()))
+                .willReturn(Optional.of(Account.builder()
+                        .accountUser(pobi)
+                        .balance(100L)
+                        .accountNumber("1000000012").build()));
+
+        //when
+        AccountException exception = assertThrows(AccountException.class,
+                () -> accountService.deleteAccount(1L, "1234567890"));
+
+        //then
+        assertEquals(ErrorCode.BALANCE_NOT_EMPTY, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("해지 계좌는 해지할 수 없다")
+    void deleteAccountFailed_alreadyUnregistered() {
+        //given
+        AccountUser pobi = AccountUser.builder()
+                .name("Pobi").build();
+        pobi.setId(12L);
+        given(accountUserRepository.findById(anyLong()))
+                .willReturn(Optional.of(pobi));
+        given(accountRepository.findByAccountNumber(anyString()))
+                .willReturn(Optional.of(Account.builder()
+                        .accountUser(pobi)
+                        .accountStatus(AccountStatus.UNREGISTERED)
+                        .balance(0L)
+                        .accountNumber("1000000012").build()));
+
+        //when
+        AccountException exception = assertThrows(AccountException.class,
+                () -> accountService.deleteAccount(1L, "1234567890"));
+
+        //then
+        assertEquals(ErrorCode.ACCOUNT_ALREADY_UNREGISTERED, exception.getErrorCode());
     }
 }

--- a/src/test/java/com/example/account/service/AccountServiceTest.java
+++ b/src/test/java/com/example/account/service/AccountServiceTest.java
@@ -1,8 +1,13 @@
 package com.example.account.service;
 
 import com.example.account.domain.Account;
-import com.example.account.domain.AccountStatus;
+import com.example.account.domain.AccountUser;
+import com.example.account.dto.AccountDto;
+import com.example.account.exception.AccountException;
+import com.example.account.repository.AccountUserRepository;
+import com.example.account.type.AccountStatus;
 import com.example.account.repository.AccountRepository;
+import com.example.account.type.ErrorCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,73 +30,100 @@ class AccountServiceTest {
     @Mock
     private AccountRepository accountRepository;
 
+    @Mock
+    private AccountUserRepository accountUserRepository;
+
     @InjectMocks
     private AccountService accountService;
 
     @Test
-    @DisplayName("계좌 조회 성공")
-    void testXXX() {
+    public void createAccountSuccess() throws Exception {
         //given
-        given(accountRepository.findById(anyLong()))
+        AccountUser user = AccountUser.builder()
+                .id(12L)
+                .name("Pobi").build();
+        given(accountUserRepository.findById(anyLong()))
+                .willReturn(Optional.of(user));
+        given(accountRepository.findFirstByOrderByIdDesc())
                 .willReturn(Optional.of(Account.builder()
-                        .accountStatus(AccountStatus.UNREGISTERED)
-                        .accountNumber("65789").build()));
-        ArgumentCaptor<Long> captor = ArgumentCaptor.forClass(Long.class);
+                        .accountNumber("1000000012").build()));
+        given(accountRepository.save(any()))
+                .willReturn(Account.builder()
+                        .accountUser(user)
+                        .accountNumber("1000000203").build());
+        ArgumentCaptor<Account> captor = ArgumentCaptor.forClass(Account.class);
 
         //when
-        Account account = accountService.getAccount(4555L);
+        AccountDto accountDto = accountService.createAccount(1L, 19L);
 
         //then
-        verify(accountRepository, times(1)).findById(captor.capture());
-        verify(accountRepository, times(0)).save(any());
-        assertEquals(4555L, captor.getValue());
-        assertNotEquals(45515L, captor.getValue());
-        assertEquals("65789", account.getAccountNumber());
-        assertEquals(AccountStatus.UNREGISTERED, account.getAccountStatus());
+        verify(accountRepository, times(1)).save(captor.capture());
+        assertEquals(12L, accountDto.getUserId());
+        assertEquals("1000000013", captor.getValue().getAccountNumber());
     }
 
     @Test
-    @DisplayName("계좌 조회 실패 - 음수로 조회")
-    void testFailedToSearchAccount() {
+    public void createFirstAccountSuccess() throws Exception {
+
         //given
+        AccountUser user = AccountUser.builder()
+                .id(15L)
+                .name("Pobi").build();
+        given(accountUserRepository.findById(anyLong()))
+                .willReturn(Optional.of(user));
+
+        given(accountRepository.findFirstByOrderByIdDesc())
+                .willReturn(Optional.empty());
+
+        given(accountRepository.save(any()))
+                .willReturn(Account.builder()
+                        .accountUser(user)
+                        .accountNumber("1000000013").build());
+
+        ArgumentCaptor<Account> captor = ArgumentCaptor.forClass(Account.class);
+
         //when
-        RuntimeException exception = assertThrows(RuntimeException.class,
-                () -> accountService.getAccount(-10L));
+        AccountDto accountDto = accountService.createAccount(1L, 19L);
 
         //then
-        assertEquals("Minus", exception.getMessage());
+        verify(accountRepository, times(1)).save(captor.capture());
+        assertEquals(15L, accountDto.getUserId());
+        assertEquals("1000000000", captor.getValue().getAccountNumber());
     }
 
     @Test
-    @DisplayName("Test 이름 변경")
-    void testGetAccount() {
+    @DisplayName("해당 유저 없음 - 계좌 생성 실패")
+    public void createAccount_UserNotFound() throws Exception {
         //given
-        given(accountRepository.findById(anyLong()))
-                .willReturn(Optional.of(Account.builder()
-                        .accountStatus(AccountStatus.UNREGISTERED)
-                        .accountNumber("65789").build()));
+        AccountUser user = AccountUser.builder()
+                .id(15L)
+                .name("Pobi").build();
 
         //when
-        Account account = accountService.getAccount(4555L);
+        AccountException exception = assertThrows(AccountException.class,
+                () -> accountService.createAccount(1L, 1000L));
 
         //then
-        assertEquals("65789", account.getAccountNumber());
-        assertEquals(AccountStatus.UNREGISTERED, account.getAccountStatus());
+        assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
     }
 
     @Test
-    void testGetAccount2() {
+    @DisplayName("유저 보유 계좌 10개 이상 - 계좌 생성 실패")
+    public void createAccount_maxAccountIs10() throws Exception {
         //given
-        given(accountRepository.findById(anyLong()))
-                .willReturn(Optional.of(Account.builder()
-                        .accountStatus(AccountStatus.UNREGISTERED)
-                        .accountNumber("65789").build()));
+        AccountUser user = AccountUser.builder()
+                .id(15L)
+                .name("Pobi").build();
+        given(accountUserRepository.findById(anyLong()))
+                .willReturn(Optional.of(user));
+        given(accountRepository.countByAccountUser(any()))
+                .willReturn(10);
 
         //when
-        Account account = accountService.getAccount(4555L);
+        AccountException exception = assertThrows(AccountException.class,
+                () -> accountService.createAccount(1L, 1000L));
 
         //then
-        assertEquals("65789", account.getAccountNumber());
-        assertEquals(AccountStatus.UNREGISTERED, account.getAccountStatus());
+        assertEquals(ErrorCode.MAX_ACCOUNT_PER_USER_10, exception.getErrorCode());
     }
 }

--- a/src/test/java/com/example/account/service/AccountServiceTest.java
+++ b/src/test/java/com/example/account/service/AccountServiceTest.java
@@ -16,6 +16,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -257,5 +259,59 @@ class AccountServiceTest {
 
         //then
         assertEquals(ErrorCode.ACCOUNT_ALREADY_UNREGISTERED, exception.getErrorCode());
+    }
+
+    @Test
+    public void successGetAccountsByUserId() throws Exception {
+        //given
+        AccountUser pobi = AccountUser.builder()
+                .name("Pobi").build();
+        pobi.setId(12L);
+        List<Account> accounts = Arrays.asList(
+                Account.builder()
+                        .accountUser(pobi)
+                        .accountNumber("1111111111")
+                        .balance(1000L)
+                        .build(),
+                Account.builder()
+                        .accountUser(pobi)
+                        .accountNumber("2222222222")
+                        .balance(2000L)
+                        .build(),
+                Account.builder()
+                        .accountUser(pobi)
+                        .accountNumber("3333333333")
+                        .balance(3000L)
+                        .build()
+        );
+        given(accountUserRepository.findById(anyLong()))
+                .willReturn(Optional.of(pobi));
+        given(accountRepository.findByAccountUser(any()))
+                .willReturn(accounts);
+
+        //when
+        List<AccountDto> accountDtos = accountService.getAccountsByUserId(1L);
+
+        //then
+        assertEquals(3, accountDtos.size());
+        assertEquals("1111111111", accountDtos.get(0).getAccountNumber());
+        assertEquals(1000, accountDtos.get(0).getBalance());
+        assertEquals("2222222222", accountDtos.get(1).getAccountNumber());
+        assertEquals(2000, accountDtos.get(1).getBalance());
+        assertEquals("3333333333", accountDtos.get(2).getAccountNumber());
+        assertEquals(3000, accountDtos.get(2).getBalance());
+    }
+
+    @Test
+    public void failedToGetAccounts() throws Exception {
+        //given
+        given(accountUserRepository.findById(anyLong()))
+                .willReturn(Optional.empty());
+        //when
+        AccountException exception = assertThrows(AccountException.class,
+                () -> accountService.getAccountsByUserId(1L));
+
+        //then
+        assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
     }
 }


### PR DESCRIPTION
# 계좌 생성 기능 구현
- POST /account
- 파라미터: 사용자 아이디, 초기 잔액
- 정책: 
    - 사용자가 없는 경우 
    - 사용자당 최대 보유 가능 계좌 수인 10개인 경우 실패 응답
- 성공 응답: 사용자 아이디, 계좌번호, 등록일시

# 계좌 해지 기능 구현
- DELETE /account
- 파라미터: 사용자 아이디, 계좌 번호
- 정책: 
    - 사용자 혹은 계좌가 없는 경우
    - 사용자 아이디와 계좌 소유주가 다른 경우
    - 계좌가 이미 해지 상태인 경우
    - 잔액이 있는 경우 실패 응답
- 성공 응답: 사용자 아이디, 계좌번호, 등록일시

# 계좌 확인 API
- GET /account?user_id={userId}
- 파라미터: 사용자 아이디
- 정책: 사용자가 없는 경우 실패 응답
- 성공 응답: List<계좌번호, 잔액> 구조로 응답

# 테스트
- AccountControllerTest 완료
- AccountServiceTest 완료