### PR TITLE
Feature/2 transaction

### DIFF
--- a/src/main/java/com/example/account/controller/TransactionController.java
+++ b/src/main/java/com/example/account/controller/TransactionController.java
@@ -1,0 +1,46 @@
+package com.example.account.controller;
+
+import com.example.account.dto.TransactionDto;
+import com.example.account.dto.UseBalance;
+import com.example.account.exception.AccountException;
+import com.example.account.service.TransactionService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+/**
+ * 잔액 관련 컨트롤러
+ * 1. 잔액 사용
+ * 2. 잔액 사용 취소
+ * 3. 거래 확인
+ */
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class TransactionController {
+    private final TransactionService transactionService;
+
+    @PostMapping("/transaction/use")
+    public UseBalance.Response useBalance(
+            @Valid @RequestBody UseBalance.Request request
+    ) {
+        try {
+            return UseBalance.Response.from(
+                    transactionService.useBalance(request.getUserId(),
+                            request.getAccountNumber(), request.getAmount()));
+        } catch (AccountException e) {
+            log.error("Failed to use balance. ");
+
+            transactionService.saveFailedUseTransaction(
+                    request.getAccountNumber(),
+                    request.getAmount()
+            );
+
+            throw e;
+        }
+    }
+}

--- a/src/main/java/com/example/account/controller/TransactionController.java
+++ b/src/main/java/com/example/account/controller/TransactionController.java
@@ -1,15 +1,14 @@
 package com.example.account.controller;
 
 import com.example.account.dto.CancelBalance;
+import com.example.account.dto.QueryTransactionResponse;
 import com.example.account.dto.TransactionDto;
 import com.example.account.dto.UseBalance;
 import com.example.account.exception.AccountException;
 import com.example.account.service.TransactionService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
@@ -64,5 +63,15 @@ public class TransactionController {
 
             throw e;
         }
+
+
+    }
+
+    @GetMapping("/transaction/{transactionId}")
+    public QueryTransactionResponse queryTransaction(
+            @PathVariable String transactionId) {
+        return QueryTransactionResponse.from(
+                transactionService.queryTransaction(transactionId)
+        );
     }
 }

--- a/src/main/java/com/example/account/controller/TransactionController.java
+++ b/src/main/java/com/example/account/controller/TransactionController.java
@@ -1,5 +1,6 @@
 package com.example.account.controller;
 
+import com.example.account.dto.CancelBalance;
 import com.example.account.dto.TransactionDto;
 import com.example.account.dto.UseBalance;
 import com.example.account.exception.AccountException;
@@ -36,6 +37,27 @@ public class TransactionController {
             log.error("Failed to use balance. ");
 
             transactionService.saveFailedUseTransaction(
+                    request.getAccountNumber(),
+                    request.getAmount()
+            );
+
+            throw e;
+        }
+    }
+
+    @PostMapping("/transaction/cancel")
+    public CancelBalance.Response cancelBalance(
+            @Valid @RequestBody CancelBalance.Request request
+    ) {
+        try {
+            return CancelBalance.Response.from(
+                    transactionService.cancelBalance(request.getTransactionId(),
+                            request.getAccountNumber(), request.getAmount())
+            );
+        } catch (AccountException e) {
+            log.error("Failed to use balance. ");
+
+            transactionService.saveFailedCancelTransaction(
                     request.getAccountNumber(),
                     request.getAmount()
             );

--- a/src/main/java/com/example/account/domain/Account.java
+++ b/src/main/java/com/example/account/domain/Account.java
@@ -45,4 +45,11 @@ public class Account {
         }
         balance -= amount;
     }
+
+    public void cancelBalance(Long amount) {
+        if (amount < 0) {
+            throw new AccountException(ErrorCode.INVALID_REQUEST);
+        }
+        balance += amount;
+    }
 }

--- a/src/main/java/com/example/account/domain/Account.java
+++ b/src/main/java/com/example/account/domain/Account.java
@@ -1,6 +1,8 @@
 package com.example.account.domain;
 
+import com.example.account.exception.AccountException;
 import com.example.account.type.AccountStatus;
+import com.example.account.type.ErrorCode;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -36,4 +38,11 @@ public class Account {
     private LocalDateTime createdAt;
     @LastModifiedDate
     private LocalDateTime updatedAt;
+
+    public void useBalance(Long amount) {
+        if (amount > balance) {
+            throw new AccountException(ErrorCode.AMOUNT_EXCEED_BALANCE);
+        }
+        balance -= amount;
+    }
 }

--- a/src/main/java/com/example/account/domain/Transaction.java
+++ b/src/main/java/com/example/account/domain/Transaction.java
@@ -1,0 +1,42 @@
+package com.example.account.domain;
+
+import com.example.account.type.TransactionResultType;
+import com.example.account.type.TransactionType;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+public class Transaction {
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private TransactionType transactionType;
+    @Enumerated(EnumType.STRING)
+    private TransactionResultType transactionResultType;
+
+    @ManyToOne
+    private Account account;
+    private Long amount;
+    private Long balanceSnapshot;
+
+    private String transactionId;
+    private LocalDateTime transactedAt;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/example/account/dto/CancelBalance.java
+++ b/src/main/java/com/example/account/dto/CancelBalance.java
@@ -1,0 +1,65 @@
+package com.example.account.dto;
+
+import com.example.account.type.TransactionResultType;
+import lombok.*;
+
+import javax.validation.constraints.*;
+import java.time.LocalDateTime;
+
+public class CancelBalance {
+    /**
+     * {
+     *    "transactionId":"dj13jfdk1fjk0kkzz",
+     *    "accountNumber":"1000000000",
+     * 	  "amount":1000
+     * }
+     */
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    public static class Request {
+        @NotBlank
+        private String transactionId;
+
+        @NotBlank
+        @Size(min = 10, max = 10)
+        private String accountNumber;
+
+        @NotNull
+        @Min(10)
+        @Max(1000_000_000)
+        private Long amount;
+    }
+
+    /**
+     * {
+     *    "accountNumber":"1234567890",
+     * 	 "transactionResult":"S",
+     * 	 "transactionId":"c2033bb6d82a4250aecf8e27c49b63f6",
+     * 	 "amount":1000,
+     *    "transactedAt":"2022-06-01T23:26:14.671859"
+     * }
+     */
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Response {
+        private String accountNumber;
+        private TransactionResultType transactionResult;
+        private String transactionId;
+        private Long amount;
+        private LocalDateTime transactedAt;
+
+        public static Response from(TransactionDto transactionDto) {
+            return Response.builder()
+                    .accountNumber(transactionDto.getAccountNumber())
+                    .transactionResult(transactionDto.getTransactionResultType())
+                    .transactionId(transactionDto.getTransactionId())
+                    .amount(transactionDto.getAmount())
+                    .transactedAt(transactionDto.getTransactedAt())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/example/account/dto/QueryTransactionResponse.java
+++ b/src/main/java/com/example/account/dto/QueryTransactionResponse.java
@@ -1,0 +1,32 @@
+package com.example.account.dto;
+
+import com.example.account.type.TransactionResultType;
+import com.example.account.type.TransactionType;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class QueryTransactionResponse {
+    private String accountNumber;
+    private TransactionType transactionType;
+    private TransactionResultType transactionResult;
+    private String transactionId;
+    private Long amount;
+    private LocalDateTime transactedAt;
+
+    public static QueryTransactionResponse from(TransactionDto transactionDto) {
+        return QueryTransactionResponse.builder()
+                .accountNumber(transactionDto.getAccountNumber())
+                .transactionType(transactionDto.getTransactionType())
+                .transactionResult(transactionDto.getTransactionResultType())
+                .transactionId(transactionDto.getTransactionId())
+                .amount(transactionDto.getAmount())
+                .transactedAt(transactionDto.getTransactedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/account/dto/TransactionDto.java
+++ b/src/main/java/com/example/account/dto/TransactionDto.java
@@ -1,0 +1,35 @@
+package com.example.account.dto;
+
+import com.example.account.domain.Transaction;
+import com.example.account.type.TransactionResultType;
+import com.example.account.type.TransactionType;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TransactionDto {
+    private String accountNumber;
+    private TransactionType transactionType;
+    private TransactionResultType transactionResultType;
+    private Long amount;
+    private Long balanceSnapshot;
+    private String transactionId;
+    private LocalDateTime transactedAt;
+
+    public static TransactionDto fromEntity(Transaction transaction) {
+        return TransactionDto.builder()
+                .accountNumber(transaction.getAccount().getAccountNumber())
+                .transactionType(transaction.getTransactionType())
+                .transactionResultType(transaction.getTransactionResultType())
+                .amount(transaction.getAmount())
+                .balanceSnapshot(transaction.getBalanceSnapshot())
+                .transactionId(transaction.getTransactionId())
+                .transactedAt(transaction.getTransactedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/account/dto/UseBalance.java
+++ b/src/main/java/com/example/account/dto/UseBalance.java
@@ -1,0 +1,60 @@
+package com.example.account.dto;
+
+import com.example.account.type.TransactionResultType;
+import lombok.*;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+import java.time.LocalDateTime;
+
+public class UseBalance {
+    /**
+     * {
+     *     "userId":1,
+     *     "accountNumber":"1000000000",
+     *     "amount": 1000
+     * }
+     * */
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    public static class Request {
+        @NonNull
+        @Min(1)
+        private Long userId;
+
+        @NotBlank
+        @Size(min=10, max=10)
+        private String accountNumber;
+
+        @NonNull
+        @Min(10)
+        @Max(1000_000_000)
+        private Long amount;
+    };
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Response {
+        private String accountNumber;
+        private TransactionResultType transactionResult;
+        private String transactionId;
+        private Long amount;
+        private LocalDateTime transactedAt;
+
+        public static Response from(TransactionDto transactionDto) {
+            return Response.builder()
+                    .accountNumber(transactionDto.getAccountNumber())
+                    .transactionResult(transactionDto.getTransactionResultType())
+                    .transactionId(transactionDto.getTransactionId())
+                    .amount(transactionDto.getAmount())
+                    .transactedAt(transactionDto.getTransactedAt())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/example/account/repository/TransactionRepository.java
+++ b/src/main/java/com/example/account/repository/TransactionRepository.java
@@ -1,0 +1,14 @@
+package com.example.account.repository;
+
+import com.example.account.domain.Transaction;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface TransactionRepository
+        extends JpaRepository<Transaction, Long> {
+
+    Optional<Transaction> findByTransactionId(String transactionId);
+}

--- a/src/main/java/com/example/account/service/TransactionService.java
+++ b/src/main/java/com/example/account/service/TransactionService.java
@@ -132,4 +132,11 @@ public class TransactionService {
 
         saveAndGetTransaction(CANCEL, F, account, amount);
     }
+
+    public TransactionDto queryTransaction(String transactionId) {
+        return TransactionDto.fromEntity(
+                transactionRepository.findByTransactionId(transactionId)
+                        .orElseThrow(() -> new AccountException(ErrorCode.TRANSACTION_NOT_FOUND))
+        );
+    }
 }

--- a/src/main/java/com/example/account/service/TransactionService.java
+++ b/src/main/java/com/example/account/service/TransactionService.java
@@ -23,6 +23,7 @@ import java.util.UUID;
 
 import static com.example.account.type.TransactionResultType.F;
 import static com.example.account.type.TransactionResultType.S;
+import static com.example.account.type.TransactionType.CANCEL;
 import static com.example.account.type.TransactionType.USE;
 
 @Slf4j
@@ -51,7 +52,7 @@ public class TransactionService {
 
         account.useBalance(amount);
 
-        return TransactionDto.fromEntity(saveAndGetTransaction(S, account, amount));
+        return TransactionDto.fromEntity(saveAndGetTransaction(USE, S, account, amount));
     }
 
     private void validateUseBalance(AccountUser user, Account account, Long amount) {
@@ -71,16 +72,17 @@ public class TransactionService {
         Account account = accountRepository.findByAccountNumber(accountNumber)
                 .orElseThrow(() -> new AccountException(ErrorCode.ACCOUNT_NOT_FOUND));
 
-        saveAndGetTransaction(F, account, amount);
+        saveAndGetTransaction(USE, F, account, amount);
     }
 
     private Transaction saveAndGetTransaction(
+            TransactionType transactionType,
             TransactionResultType transactionResultType,
             Account account,
             Long amount) {
         return transactionRepository.save(
                 Transaction.builder()
-                        .transactionType(USE)
+                        .transactionType(transactionType)
                         .transactionResultType(transactionResultType)
                         .account(account)
                         .amount(amount)
@@ -89,5 +91,45 @@ public class TransactionService {
                         .transactedAt(LocalDateTime.now())
                         .build()
         );
+    }
+
+    @Transactional
+    public TransactionDto cancelBalance(
+            String transactionId,
+            String accountNumber,
+            Long amount
+    ) {
+        Transaction transaction = transactionRepository.findByTransactionId(transactionId)
+                .orElseThrow(() -> new AccountException(ErrorCode.TRANSACTION_NOT_FOUND));
+        Account account = accountRepository.findByAccountNumber(accountNumber)
+                .orElseThrow(() -> new AccountException(ErrorCode.ACCOUNT_NOT_FOUND));
+
+        validateCancelBalance(transaction, account, amount);
+
+        account.cancelBalance(amount);
+
+        return TransactionDto.fromEntity(
+                saveAndGetTransaction(CANCEL, S, account, amount)
+        );
+    }
+
+    private void validateCancelBalance(Transaction transaction, Account account, Long amount) {
+        if (!Objects.equals(transaction.getAccount().getId(), account.getId())) {
+            throw new AccountException(ErrorCode.TRANSACTION_ACCOUNT_UN_MATCH);
+        }
+        if (!Objects.equals(transaction.getAmount(), amount)) {
+            throw new AccountException(ErrorCode.CANCEL_MUST_FULLY);
+        }
+        if (transaction.getTransactedAt().isBefore(LocalDateTime.now().minusYears(1))) {
+            throw new AccountException(ErrorCode.TOO_OLD_ORDER_TO_CANCEL);
+        }
+    }
+
+    @Transactional
+    public void saveFailedCancelTransaction(String accountNumber, Long amount) {
+        Account account = accountRepository.findByAccountNumber(accountNumber)
+                .orElseThrow(() -> new AccountException(ErrorCode.ACCOUNT_NOT_FOUND));
+
+        saveAndGetTransaction(CANCEL, F, account, amount);
     }
 }

--- a/src/main/java/com/example/account/service/TransactionService.java
+++ b/src/main/java/com/example/account/service/TransactionService.java
@@ -1,0 +1,93 @@
+package com.example.account.service;
+
+import com.example.account.domain.Account;
+import com.example.account.domain.AccountUser;
+import com.example.account.domain.Transaction;
+import com.example.account.dto.TransactionDto;
+import com.example.account.exception.AccountException;
+import com.example.account.repository.AccountRepository;
+import com.example.account.repository.AccountUserRepository;
+import com.example.account.repository.TransactionRepository;
+import com.example.account.type.AccountStatus;
+import com.example.account.type.ErrorCode;
+import com.example.account.type.TransactionResultType;
+import com.example.account.type.TransactionType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import java.util.UUID;
+
+import static com.example.account.type.TransactionResultType.F;
+import static com.example.account.type.TransactionResultType.S;
+import static com.example.account.type.TransactionType.USE;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TransactionService {
+    private final TransactionRepository transactionRepository;
+    private final AccountUserRepository accountUserRepository;
+    private final AccountRepository accountRepository;
+
+    /**
+     * 사용자 없는 경우, 계좌가 없는 경우, 사용자 아이디와 계좌 소유주가 다른 경우,
+     * 계좌가 이미 해지 상태인 경우, 거래금액이 잔액보다 큰 경우,
+     * 거래금액이 너무 작거나 큰 경우 실패 응답
+     */
+    @Transactional
+    public TransactionDto useBalance(Long userId, String accountNumber,
+                                     Long amount) {
+
+        AccountUser user = accountUserRepository.findById(userId)
+                .orElseThrow(() -> new AccountException(ErrorCode.USER_NOT_FOUND));
+        Account account = accountRepository.findByAccountNumber(accountNumber)
+                .orElseThrow(() -> new AccountException(ErrorCode.ACCOUNT_NOT_FOUND));
+
+        validateUseBalance(user, account, amount);
+
+        account.useBalance(amount);
+
+        return TransactionDto.fromEntity(saveAndGetTransaction(S, account, amount));
+    }
+
+    private void validateUseBalance(AccountUser user, Account account, Long amount) {
+        if (!Objects.equals(user.getId(), account.getAccountUser().getId())) {
+            throw new AccountException(ErrorCode.USER_ACCOUNT_UN_MATCH);
+        }
+        if (account.getAccountStatus() != AccountStatus.IN_USE) {
+            throw new AccountException(ErrorCode.ACCOUNT_ALREADY_UNREGISTERED);
+        }
+        if (account.getBalance() < amount) {
+            throw new AccountException(ErrorCode.AMOUNT_EXCEED_BALANCE);
+        }
+    }
+
+    @Transactional
+    public void saveFailedUseTransaction(String accountNumber, Long amount) {
+        Account account = accountRepository.findByAccountNumber(accountNumber)
+                .orElseThrow(() -> new AccountException(ErrorCode.ACCOUNT_NOT_FOUND));
+
+        saveAndGetTransaction(F, account, amount);
+    }
+
+    private Transaction saveAndGetTransaction(
+            TransactionResultType transactionResultType,
+            Account account,
+            Long amount) {
+        return transactionRepository.save(
+                Transaction.builder()
+                        .transactionType(USE)
+                        .transactionResultType(transactionResultType)
+                        .account(account)
+                        .amount(amount)
+                        .balanceSnapshot(account.getBalance())
+                        .transactionId(UUID.randomUUID().toString().replace("-", ""))
+                        .transactedAt(LocalDateTime.now())
+                        .build()
+        );
+    }
+}

--- a/src/main/java/com/example/account/type/ErrorCode.java
+++ b/src/main/java/com/example/account/type/ErrorCode.java
@@ -6,9 +6,14 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public enum ErrorCode {
+    INVALID_REQUEST("잘못된 요청입니다."),
     USER_NOT_FOUND("사용자를 찾을 수 없습니다."),
     ACCOUNT_NOT_FOUND("계좌가 없습니다."),
+    TRANSACTION_NOT_FOUND("해당 거래가 없습니다."),
     AMOUNT_EXCEED_BALANCE("거래 금액이 계좌 잔액보다 큽니다. "),
+    TRANSACTION_ACCOUNT_UN_MATCH("이 거래는 해당 계좌에서 발생한 거래가 아닙니다."),
+    CANCEL_MUST_FULLY("부분 취소는 허용되지 않습니다."),
+    TOO_OLD_ORDER_TO_CANCEL("1년이 지난 거래는 취소가 불가능합니다."),
     USER_ACCOUNT_UN_MATCH("사용자와 계좌의 소유주가 다릅니다."),
     ACCOUNT_ALREADY_UNREGISTERED("계좌가 이미 해제되었습니다."),
     BALANCE_NOT_EMPTY("잔액이 있는 계좌는 해지할 수 없습니다."),

--- a/src/main/java/com/example/account/type/ErrorCode.java
+++ b/src/main/java/com/example/account/type/ErrorCode.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 public enum ErrorCode {
     USER_NOT_FOUND("사용자를 찾을 수 없습니다."),
     ACCOUNT_NOT_FOUND("계좌가 없습니다."),
+    AMOUNT_EXCEED_BALANCE("거래 금액이 계좌 잔액보다 큽니다. "),
     USER_ACCOUNT_UN_MATCH("사용자와 계좌의 소유주가 다릅니다."),
     ACCOUNT_ALREADY_UNREGISTERED("계좌가 이미 해제되었습니다."),
     BALANCE_NOT_EMPTY("잔액이 있는 계좌는 해지할 수 없습니다."),

--- a/src/main/java/com/example/account/type/TransactionResultType.java
+++ b/src/main/java/com/example/account/type/TransactionResultType.java
@@ -1,0 +1,5 @@
+package com.example.account.type;
+
+public enum TransactionResultType {
+    S, F
+}

--- a/src/main/java/com/example/account/type/TransactionType.java
+++ b/src/main/java/com/example/account/type/TransactionType.java
@@ -1,0 +1,5 @@
+package com.example.account.type;
+
+public enum TransactionType {
+    USE, CANCEL
+}

--- a/src/test/http/account.http
+++ b/src/test/http/account.http
@@ -7,7 +7,7 @@ Content-Type: application/json
 
 {
   "userId": 1,
-  "initialBalance": 10004
+  "initialBalance": 12345000
 }
 
 ### delete account

--- a/src/test/http/transaction.http
+++ b/src/test/http/transaction.http
@@ -23,10 +23,10 @@ POST http://localhost:8080/transaction/cancel
 Content-Type: application/json
 
 {
-  "transactionId": "dd994cbd6fff4fcaa1a9e9acf1827336",
+  "transactionId": "974b7a88eff74d6eb87be09ac422ddf5",
   "accountNumber": "1000000002",
   "amount":20000
 }
 
 ### query transaction
-GET http://localhost:8080/transaction/6b4c7f21e8944650ba99cd41afdf8d26
+GET http://localhost:8080/transaction/974b7a88eff74d6eb87be09ac422ddf5

--- a/src/test/http/transaction.http
+++ b/src/test/http/transaction.http
@@ -1,0 +1,32 @@
+### use balance
+POST http://localhost:8080/transaction/use
+Content-Type: application/json
+
+{
+  "userId": 1,
+  "accountNumber": "1000000000",
+  "amount": 10000
+}
+#
+#### use balance2
+#POST http://localhost:8080/transaction/use
+#Content-Type: application/json
+#
+#{
+#  "userId": 1,
+#  "accountNumber": "1000000002",
+#  "amount":100
+#}
+#
+#### cancel balance
+#POST http://localhost:8080/transaction/cancel
+#Content-Type: application/json
+#
+#{
+#  "transactionId": "8e99662991aa4bef8e48686f9607e2b0",
+#  "accountNumber": "1000000002",
+#  "amount":100
+#}
+#
+#### query transaction
+#GET http://localhost:8080/transaction/6b4c7f21e8944650ba99cd41afdf8d26

--- a/src/test/http/transaction.http
+++ b/src/test/http/transaction.http
@@ -4,29 +4,29 @@ Content-Type: application/json
 
 {
   "userId": 1,
-  "accountNumber": "1000000000",
-  "amount": 10000
+  "accountNumber": "1000000002",
+  "amount": 20000
 }
-#
-#### use balance2
-#POST http://localhost:8080/transaction/use
-#Content-Type: application/json
-#
-#{
-#  "userId": 1,
-#  "accountNumber": "1000000002",
-#  "amount":100
-#}
-#
-#### cancel balance
-#POST http://localhost:8080/transaction/cancel
-#Content-Type: application/json
-#
-#{
-#  "transactionId": "8e99662991aa4bef8e48686f9607e2b0",
-#  "accountNumber": "1000000002",
-#  "amount":100
-#}
-#
-#### query transaction
-#GET http://localhost:8080/transaction/6b4c7f21e8944650ba99cd41afdf8d26
+
+### use balance2
+POST http://localhost:8080/transaction/use
+Content-Type: application/json
+
+{
+  "userId": 1,
+  "accountNumber": "1000000002",
+  "amount":100
+}
+
+### cancel balance
+POST http://localhost:8080/transaction/cancel
+Content-Type: application/json
+
+{
+  "transactionId": "dd994cbd6fff4fcaa1a9e9acf1827336",
+  "accountNumber": "1000000002",
+  "amount":20000
+}
+
+### query transaction
+GET http://localhost:8080/transaction/6b4c7f21e8944650ba99cd41afdf8d26

--- a/src/test/java/com/example/account/controller/TransactionControllerTest.java
+++ b/src/test/java/com/example/account/controller/TransactionControllerTest.java
@@ -1,6 +1,7 @@
 package com.example.account.controller;
 
 import com.example.account.dto.AccountDto;
+import com.example.account.dto.CancelBalance;
 import com.example.account.dto.TransactionDto;
 import com.example.account.dto.UseBalance;
 import com.example.account.service.TransactionService;
@@ -65,4 +66,34 @@ class TransactionControllerTest {
                 .andExpect(jsonPath("$.transactionId").value("transactionId"))
                 .andExpect(jsonPath("$.amount").value(12345));
     }
+
+    @Test
+    public void successCancelBalance() throws Exception {
+        //given
+        given(transactionService.cancelBalance(anyString(), anyString(), anyLong()))
+                .willReturn(TransactionDto.builder()
+                        .accountNumber("1000000000")
+                        .transactedAt(LocalDateTime.now())
+                        .amount(54321L)
+                        .transactionId("transactionIdForCancel")
+                        .transactionResultType(S)
+                        .build());
+
+        //when
+        //then
+        mockMvc.perform(post("/transaction/cancel")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new CancelBalance.Request("transactionId",
+                                        "2000000000", 3000L)
+                        ))
+                ).andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accountNumber").value("1000000000"))
+                .andExpect(jsonPath("$.transactionResult").value("S"))
+                .andExpect(jsonPath("$.transactionId").value("transactionIdForCancel"))
+                .andExpect(jsonPath("$.amount").value(54321));
+    }
+
+
 }

--- a/src/test/java/com/example/account/controller/TransactionControllerTest.java
+++ b/src/test/java/com/example/account/controller/TransactionControllerTest.java
@@ -1,0 +1,68 @@
+package com.example.account.controller;
+
+import com.example.account.dto.AccountDto;
+import com.example.account.dto.TransactionDto;
+import com.example.account.dto.UseBalance;
+import com.example.account.service.TransactionService;
+import com.example.account.type.TransactionType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static com.example.account.type.TransactionResultType.S;
+import static com.example.account.type.TransactionType.USE;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(TransactionController.class)
+class TransactionControllerTest {
+    @MockBean
+    private TransactionService transactionService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void successUseBalance() throws Exception {
+        //given
+        given(transactionService.useBalance(anyLong(), anyString(), anyLong()))
+                .willReturn(TransactionDto.builder()
+                        .accountNumber("1000000000")
+                        .transactedAt(LocalDateTime.now())
+                        .amount(12345L)
+                        .transactionId("transactionId")
+                        .transactionResultType(S)
+                        .build());
+
+        //when
+        //then
+        mockMvc.perform(post("/transaction/use")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new UseBalance.Request(1L, "2000000000", 3000L)
+                        ))
+                ).andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accountNumber").value("1000000000"))
+                .andExpect(jsonPath("$.transactionResult").value("S"))
+                .andExpect(jsonPath("$.transactionId").value("transactionId"))
+                .andExpect(jsonPath("$.amount").value(12345));
+    }
+}

--- a/src/test/java/com/example/account/controller/TransactionControllerTest.java
+++ b/src/test/java/com/example/account/controller/TransactionControllerTest.java
@@ -1,9 +1,6 @@
 package com.example.account.controller;
 
-import com.example.account.dto.AccountDto;
-import com.example.account.dto.CancelBalance;
-import com.example.account.dto.TransactionDto;
-import com.example.account.dto.UseBalance;
+import com.example.account.dto.*;
 import com.example.account.service.TransactionService;
 import com.example.account.type.TransactionType;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -13,6 +10,8 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 
 import java.time.LocalDateTime;
 import java.util.Arrays;
@@ -96,4 +95,28 @@ class TransactionControllerTest {
     }
 
 
+    @Test
+    void successQueryTransaction() throws Exception {
+        //given
+        given(transactionService.queryTransaction(anyString()))
+                .willReturn(TransactionDto.builder()
+                        .accountNumber("1000000000")
+                        .transactionType(USE)
+                        .transactedAt(LocalDateTime.now())
+                        .amount(54321L)
+                        .transactionId("transactionIdForCancel")
+                        .transactionResultType(S)
+                        .build());
+
+        //when
+        //then
+        mockMvc.perform(get("/transaction/12345"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accountNumber").value("1000000000"))
+                .andExpect(jsonPath("$.transactionType").value("USE"))
+                .andExpect(jsonPath("$.transactionResult").value("S"))
+                .andExpect(jsonPath("$.transactionId").value("transactionIdForCancel"))
+                .andExpect(jsonPath("$.amount").value(54321));
+    }
 }

--- a/src/test/java/com/example/account/service/TransactionServiceTest.java
+++ b/src/test/java/com/example/account/service/TransactionServiceTest.java
@@ -236,4 +236,216 @@ class TransactionServiceTest {
         assertEquals(10000L, captor.getValue().getBalanceSnapshot());
         assertEquals(F, captor.getValue().getTransactionResultType());
     }
+
+    @Test
+    void successCancelBalance() {
+        //given
+        AccountUser user = AccountUser.builder()
+                .name("Pobi").build();
+        user.setId(12L);
+        Account account = Account.builder()
+                .accountUser(user)
+                .accountStatus(IN_USE)
+                .balance(10000L)
+                .accountNumber("1000000012").build();
+        Transaction transaction = Transaction.builder()
+                .account(account)
+                .transactionType(USE)
+                .transactionResultType(S)
+                .transactionId("transactionId")
+                .transactedAt(LocalDateTime.now())
+                .amount(CANCEL_AMOUNT)
+                .balanceSnapshot(9000L)
+                .build();
+        given(transactionRepository.findByTransactionId(anyString()))
+                .willReturn(Optional.of(transaction));
+        given(accountRepository.findByAccountNumber(anyString()))
+                .willReturn(Optional.of(account));
+        given(transactionRepository.save(any()))
+                .willReturn(Transaction.builder()
+                        .account(account)
+                        .transactionType(CANCEL)
+                        .transactionResultType(S)
+                        .transactionId("transactionIdForCancel")
+                        .transactedAt(LocalDateTime.now())
+                        .amount(CANCEL_AMOUNT)
+                        .balanceSnapshot(10000L)
+                        .build());
+        ArgumentCaptor<Transaction> captor = ArgumentCaptor.forClass(Transaction.class);
+
+        //when
+        TransactionDto transactionDto = transactionService.cancelBalance("transactionId",
+                "1000000000", CANCEL_AMOUNT);
+
+        //then
+        verify(transactionRepository, times(1)).save(captor.capture());
+        assertEquals(CANCEL_AMOUNT, captor.getValue().getAmount());
+        assertEquals(10000L + CANCEL_AMOUNT, captor.getValue().getBalanceSnapshot());
+        assertEquals(S, transactionDto.getTransactionResultType());
+        assertEquals(CANCEL, transactionDto.getTransactionType());
+        assertEquals(10000L, transactionDto.getBalanceSnapshot());
+        assertEquals(CANCEL_AMOUNT, transactionDto.getAmount());
+    }
+
+    @Test
+    @DisplayName("해당 계좌 없음 - 잔액 사용 취소 실패")
+    void cancelTransaction_AccountNotFound() {
+        //given
+        given(transactionRepository.findByTransactionId(anyString()))
+                .willReturn(Optional.of(Transaction.builder().build()));
+        given(accountRepository.findByAccountNumber(anyString()))
+                .willReturn(Optional.empty());
+
+        //when
+        AccountException exception = assertThrows(AccountException.class,
+                () -> transactionService.cancelBalance("transactionId", "1000000000", 1000L));
+
+        //then
+        assertEquals(ErrorCode.ACCOUNT_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("원 사용 거래 없음 - 잔액 사용 취소 실패")
+    void cancelTransaction_TransactionNotFound() {
+        //given
+        given(transactionRepository.findByTransactionId(anyString()))
+                .willReturn(Optional.empty());
+
+        //when
+        AccountException exception = assertThrows(AccountException.class,
+                () -> transactionService.cancelBalance("transactionId", "1000000000", 1000L));
+
+        //then
+        assertEquals(ErrorCode.TRANSACTION_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("거래와 계좌가 매칭실패 - 잔액 사용 취소 실패")
+    void cancelTransaction_TransactionAccountUnMatch() {
+        //given
+        AccountUser user = AccountUser.builder()
+                .name("Pobi").build();
+        user.setId(12L);
+        Account account = Account.builder()
+                .accountUser(user)
+                .accountStatus(IN_USE)
+                .balance(10000L)
+                .accountNumber("1000000012").build();
+        account.setId(1L);
+        Account accountNotUse = Account.builder()
+                .accountUser(user)
+                .accountStatus(IN_USE)
+                .balance(10000L)
+                .accountNumber("1000000013").build();
+        accountNotUse.setId(2L);
+        Transaction transaction = Transaction.builder()
+                .account(account)
+                .transactionType(USE)
+                .transactionResultType(S)
+                .transactionId("transactionId")
+                .transactedAt(LocalDateTime.now())
+                .amount(CANCEL_AMOUNT)
+                .balanceSnapshot(9000L)
+                .build();
+        given(transactionRepository.findByTransactionId(anyString()))
+                .willReturn(Optional.of(transaction));
+        given(accountRepository.findByAccountNumber(anyString()))
+                .willReturn(Optional.of(accountNotUse));
+
+        //when
+        AccountException exception = assertThrows(AccountException.class,
+                () -> transactionService
+                        .cancelBalance(
+                                "transactionId",
+                                "1000000000",
+                                CANCEL_AMOUNT
+                        )
+        );
+
+        //then
+        assertEquals(ErrorCode.TRANSACTION_ACCOUNT_UN_MATCH, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("거래금액과 취소금액이 다름 - 잔액 사용 취소 실패")
+    void cancelTransaction_CancelMustFully() {
+        //given
+        AccountUser user = AccountUser.builder()
+                .name("Pobi").build();
+        user.setId(12L);
+        Account account = Account.builder()
+                .accountUser(user)
+                .accountStatus(IN_USE)
+                .balance(10000L)
+                .accountNumber("1000000012").build();
+        account.setId(1L);
+        Transaction transaction = Transaction.builder()
+                .account(account)
+                .transactionType(USE)
+                .transactionResultType(S)
+                .transactionId("transactionId")
+                .transactedAt(LocalDateTime.now())
+                .amount(CANCEL_AMOUNT + 1000L)
+                .balanceSnapshot(9000L)
+                .build();
+        given(transactionRepository.findByTransactionId(anyString()))
+                .willReturn(Optional.of(transaction));
+        given(accountRepository.findByAccountNumber(anyString()))
+                .willReturn(Optional.of(account));
+
+        //when
+        AccountException exception = assertThrows(AccountException.class,
+                () -> transactionService
+                        .cancelBalance(
+                                "transactionId",
+                                "1000000000",
+                                CANCEL_AMOUNT
+                        )
+        );
+
+        //then
+        assertEquals(ErrorCode.CANCEL_MUST_FULLY, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("취소는 1년까지만 가능 - 잔액 사용 취소 실패")
+    void cancelTransaction_TooOldOrder() {
+        //given
+        AccountUser user = AccountUser.builder()
+                .name("Pobi").build();
+        user.setId(12L);
+        Account account = Account.builder()
+                .accountUser(user)
+                .accountStatus(IN_USE)
+                .balance(10000L)
+                .accountNumber("1000000012").build();
+        account.setId(1L);
+        Transaction transaction = Transaction.builder()
+                .account(account)
+                .transactionType(USE)
+                .transactionResultType(S)
+                .transactionId("transactionId")
+                .transactedAt(LocalDateTime.now().minusYears(1))
+                .amount(CANCEL_AMOUNT)
+                .balanceSnapshot(9000L)
+                .build();
+        given(transactionRepository.findByTransactionId(anyString()))
+                .willReturn(Optional.of(transaction));
+        given(accountRepository.findByAccountNumber(anyString()))
+                .willReturn(Optional.of(account));
+
+        //when
+        AccountException exception = assertThrows(AccountException.class,
+                () -> transactionService
+                        .cancelBalance(
+                                "transactionId",
+                                "1000000000",
+                                CANCEL_AMOUNT
+                        )
+        );
+
+        //then
+        assertEquals(ErrorCode.TOO_OLD_ORDER_TO_CANCEL, exception.getErrorCode());
+    }
+
 }

--- a/src/test/java/com/example/account/service/TransactionServiceTest.java
+++ b/src/test/java/com/example/account/service/TransactionServiceTest.java
@@ -448,4 +448,52 @@ class TransactionServiceTest {
         assertEquals(ErrorCode.TOO_OLD_ORDER_TO_CANCEL, exception.getErrorCode());
     }
 
+    @Test
+    void successQueryTransaction() {
+        //given
+        AccountUser user = AccountUser.builder()
+                .name("Pobi").build();
+        user.setId(12L);
+        Account account = Account.builder()
+                .accountUser(user)
+                .accountStatus(IN_USE)
+                .balance(10000L)
+                .accountNumber("1000000012").build();
+        account.setId(1L);
+        Transaction transaction = Transaction.builder()
+                .account(account)
+                .transactionType(USE)
+                .transactionResultType(S)
+                .transactionId("transactionId")
+                .transactedAt(LocalDateTime.now().minusYears(1))
+                .amount(CANCEL_AMOUNT)
+                .balanceSnapshot(9000L)
+                .build();
+        given(transactionRepository.findByTransactionId(anyString()))
+                .willReturn(Optional.of(transaction));
+
+        //when
+        TransactionDto transactionDto = transactionService.queryTransaction("trxId");
+
+        //then
+        assertEquals(USE, transactionDto.getTransactionType());
+        assertEquals(S, transactionDto.getTransactionResultType());
+        assertEquals(CANCEL_AMOUNT, transactionDto.getAmount());
+        assertEquals("transactionId", transactionDto.getTransactionId());
+    }
+
+    @Test
+    @DisplayName("원거래 없음 - 거래 조회 실패")
+    void queryTransaction_TransactionNotFound() {
+        //given
+        given(transactionRepository.findByTransactionId(anyString()))
+                .willReturn(Optional.empty());
+
+        //when
+        AccountException exception = assertThrows(AccountException.class,
+                () -> transactionService.queryTransaction("transactionId"));
+
+        //then
+        assertEquals(ErrorCode.TRANSACTION_NOT_FOUND, exception.getErrorCode());
+    }
 }

--- a/src/test/java/com/example/account/service/TransactionServiceTest.java
+++ b/src/test/java/com/example/account/service/TransactionServiceTest.java
@@ -1,0 +1,239 @@
+package com.example.account.service;
+
+import com.example.account.domain.Account;
+import com.example.account.domain.AccountUser;
+import com.example.account.domain.Transaction;
+import com.example.account.dto.TransactionDto;
+import com.example.account.exception.AccountException;
+import com.example.account.repository.AccountRepository;
+import com.example.account.repository.AccountUserRepository;
+import com.example.account.repository.TransactionRepository;
+import com.example.account.type.AccountStatus;
+import com.example.account.type.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static com.example.account.type.AccountStatus.IN_USE;
+import static com.example.account.type.TransactionResultType.F;
+import static com.example.account.type.TransactionResultType.S;
+import static com.example.account.type.TransactionType.CANCEL;
+import static com.example.account.type.TransactionType.USE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class TransactionServiceTest {
+    public static final long USE_AMOUNT = 200L;
+    public static final long CANCEL_AMOUNT = 200L;
+    @Mock
+    private TransactionRepository transactionRepository;
+
+    @Mock
+    private AccountRepository accountRepository;
+
+    @Mock
+    private AccountUserRepository accountUserRepository;
+
+    @InjectMocks
+    private TransactionService transactionService;
+
+    @Test
+    public void successUseBalance() {
+        //given
+        AccountUser user = AccountUser.builder()
+                .name("Pobi").build();
+        user.setId(12L);
+        Account account = Account.builder()
+                .accountUser(user)
+                .accountStatus(IN_USE)
+                .balance(10000L)
+                .accountNumber("1000000012").build();
+        given(accountUserRepository.findById(anyLong()))
+                .willReturn(Optional.of(user));
+        given(accountRepository.findByAccountNumber(anyString()))
+                .willReturn(Optional.of(account));
+        given(transactionRepository.save(any()))
+                .willReturn(Transaction.builder()
+                        .account(account)
+                        .transactionType(USE)
+                        .transactionResultType(S)
+                        .transactionId("transactionId")
+                        .transactedAt(LocalDateTime.now())
+                        .amount(1000L)
+                        .balanceSnapshot(9000L)
+                        .build());
+        ArgumentCaptor<Transaction> captor = ArgumentCaptor.forClass(Transaction.class);
+
+        //when
+        TransactionDto transactionDto = transactionService.useBalance(1L,
+                "1000000000", USE_AMOUNT);
+
+        //then
+        verify(transactionRepository, times(1)).save(captor.capture());
+        assertEquals(USE_AMOUNT, captor.getValue().getAmount());
+        assertEquals(9800L, captor.getValue().getBalanceSnapshot());
+        assertEquals(S, transactionDto.getTransactionResultType());
+        assertEquals(USE, transactionDto.getTransactionType());
+        assertEquals(9000L, transactionDto.getBalanceSnapshot());
+        assertEquals(1000L, transactionDto.getAmount());
+    }
+
+    @Test
+    @DisplayName("해당 유저 없음 - 잔액 사용 실패")
+    void useBalance_UserNotFound() {
+        //given
+        given(accountUserRepository.findById(anyLong()))
+                .willReturn(Optional.empty());
+
+        //when
+        AccountException exception = assertThrows(AccountException.class,
+                () -> transactionService.useBalance(1L, "1000000000", 1000L));
+
+        //then
+        assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("해당 계좌 없음 - 잔액 사용 실패")
+    void deleteAccount_AccountNotFound() {
+        //given
+        AccountUser user = AccountUser.builder()
+                .name("Pobi").build();
+        user.setId(12L);
+        given(accountUserRepository.findById(anyLong()))
+                .willReturn(Optional.of(user));
+        given(accountRepository.findByAccountNumber(anyString()))
+                .willReturn(Optional.empty());
+
+        //when
+        AccountException exception = assertThrows(AccountException.class,
+                () -> transactionService.useBalance(1L, "1000000000", 1000L));
+
+        //then
+        assertEquals(ErrorCode.ACCOUNT_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("계좌 소유주 다름 - 잔액 사용 실패")
+    void deleteAccountFailed_userUnMatch() {
+        //given
+        AccountUser pobi = AccountUser.builder()
+                .name("Pobi").build();
+        pobi.setId(12L);
+        AccountUser harry = AccountUser.builder()
+                .name("Harry").build();
+        harry.setId(13L);
+        given(accountUserRepository.findById(anyLong()))
+                .willReturn(Optional.of(pobi));
+        given(accountRepository.findByAccountNumber(anyString()))
+                .willReturn(Optional.of(Account.builder()
+                        .accountUser(harry)
+                        .balance(0L)
+                        .accountNumber("1000000012").build()));
+
+        //when
+        AccountException exception = assertThrows(AccountException.class,
+                () -> transactionService.useBalance(1L, "1234567890", 1000L));
+
+        //then
+        assertEquals(ErrorCode.USER_ACCOUNT_UN_MATCH, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("해지 계좌는 사용할 수 없다")
+    void deleteAccountFailed_alreadyUnregistered() {
+        //given
+        AccountUser pobi = AccountUser.builder()
+                .name("Pobi").build();
+        pobi.setId(12L);
+        given(accountUserRepository.findById(anyLong()))
+                .willReturn(Optional.of(pobi));
+        given(accountRepository.findByAccountNumber(anyString()))
+                .willReturn(Optional.of(Account.builder()
+                        .accountUser(pobi)
+                        .accountStatus(AccountStatus.UNREGISTERED)
+                        .balance(0L)
+                        .accountNumber("1000000012").build()));
+
+        //when
+        AccountException exception = assertThrows(AccountException.class,
+                () -> transactionService.useBalance(1L, "1234567890", 1000L));
+
+        //then
+        assertEquals(ErrorCode.ACCOUNT_ALREADY_UNREGISTERED, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("거래 금액이 잔액보다 큰 경우")
+    void exceedAmount_UseBalance() {
+        //given
+        AccountUser user = AccountUser.builder()
+                .name("Pobi").build();
+        user.setId(12L);
+        Account account = Account.builder()
+                .accountUser(user)
+                .accountStatus(IN_USE)
+                .balance(100L)
+                .accountNumber("1000000012").build();
+        given(accountUserRepository.findById(anyLong()))
+                .willReturn(Optional.of(user));
+        given(accountRepository.findByAccountNumber(anyString()))
+                .willReturn(Optional.of(account));
+
+        //when
+        //then
+        AccountException exception = assertThrows(AccountException.class,
+                () -> transactionService.useBalance(1L, "1234567890", 1000L));
+
+        assertEquals(ErrorCode.AMOUNT_EXCEED_BALANCE, exception.getErrorCode());
+        verify(transactionRepository, times(0)).save(any());
+    }
+
+    @Test
+    @DisplayName("실패 트랜잭션 저장 성공")
+    void saveFailedUseTransaction() {
+        //given
+        AccountUser user = AccountUser.builder()
+                .name("Pobi").build();
+        user.setId(12L);
+        Account account = Account.builder()
+                .accountUser(user)
+                .accountStatus(IN_USE)
+                .balance(10000L)
+                .accountNumber("1000000012").build();
+        given(accountRepository.findByAccountNumber(anyString()))
+                .willReturn(Optional.of(account));
+        given(transactionRepository.save(any()))
+                .willReturn(Transaction.builder()
+                        .account(account)
+                        .transactionType(USE)
+                        .transactionResultType(S)
+                        .transactionId("transactionId")
+                        .transactedAt(LocalDateTime.now())
+                        .amount(1000L)
+                        .balanceSnapshot(9000L)
+                        .build());
+        ArgumentCaptor<Transaction> captor = ArgumentCaptor.forClass(Transaction.class);
+
+        //when
+        transactionService.saveFailedUseTransaction("1000000000", USE_AMOUNT);
+
+        //then
+        verify(transactionRepository, times(1)).save(captor.capture());
+        assertEquals(USE_AMOUNT, captor.getValue().getAmount());
+        assertEquals(10000L, captor.getValue().getBalanceSnapshot());
+        assertEquals(F, captor.getValue().getTransactionResultType());
+    }
+}


### PR DESCRIPTION
# Transaction
## 잔액 사용 API

- POST /transaction/use
- 파라미터: 사용자 아이디, 계좌번호, 거래 금액
- 정책:
    - 사용자 없는 경우
    - 사용자 아이디와 계좌 소유주가 다른 경우
    - 계좌가 이미 해지 상태인 경우
    - 거래 금액이 잔액보다 큰 경우
    - 거래금액이 너무 작거나 큰 경우 실패 응답
- 성공 응답: 계좌번호, 거래 결과 코드(S/F), 거래 아이디, 거래금액, 거래일시


## 잔액 사용 취소 API
- POST /transaction/cancel
- 파라미터: 거래 아이디, 취소 요청 금액
- 정책:
    - 거래 아이디에 해당하는 거래가 없는 경우
    - 거래금액과 거래 취소 금액이 다른 경우(부분 취소 불가능) 실패 응답
    - 1년이 넘은 거래는 사용 취소 불가능
- 성공 응답: 계좌번호, 거래 결과 코드(S/F), 거래 아이디, 거래금액, 거래일시


## 거래 확인 API
- POST /transaction/{transactionId}
- 파라미터: 거래 아이디
- 정책:
    - 해당 거래 아이디의 거래가 없는 경우 실패 응답
- 성공 응답: 계좌번호, 거래종류(잔액 사용, 잔액 사용 취소), 거래 결과 코드(S/F), 거래 아이디, 거래금액, 거래일시
    - 실패한 거래(사용/사용취소)도 거래 확인 가능